### PR TITLE
Add Content-Length to PUT requests

### DIFF
--- a/bin/swauth-add-account
+++ b/bin/swauth-add-account
@@ -58,7 +58,8 @@ if __name__ == '__main__':
         parsed_path += '/'
     path = '%sv2/%s' % (parsed_path, account)
     headers = {'X-Auth-Admin-User': options.admin_user,
-               'X-Auth-Admin-Key': options.admin_key}
+               'X-Auth-Admin-Key': options.admin_key,
+               'Content-Length': '0'}
     if options.suffix:
         headers['X-Account-Suffix'] = options.suffix
     conn = http_connect(parsed.hostname, parsed.port, 'PUT', path, headers,

--- a/bin/swauth-add-user
+++ b/bin/swauth-add-user
@@ -76,6 +76,7 @@ if __name__ == '__main__':
                         ssl=(parsed.scheme == 'https'))
     resp = conn.getresponse()
     if resp.status // 100 != 2:
+        headers['Content-Length'] = '0'
         conn = http_connect(parsed.hostname, parsed.port, 'PUT', path, headers,
                             ssl=(parsed.scheme == 'https'))
         resp = conn.getresponse()
@@ -85,7 +86,8 @@ if __name__ == '__main__':
     path = '%sv2/%s/%s' % (parsed_path, account, user)
     headers = {'X-Auth-Admin-User': options.admin_user,
                'X-Auth-Admin-Key': options.admin_key,
-               'X-Auth-User-Key': password}
+               'X-Auth-User-Key': password,
+               'Content-Length': '0'}
     if options.admin:
         headers['X-Auth-User-Admin'] = 'true'
     if options.reseller_admin:

--- a/swauth/middleware.py
+++ b/swauth/middleware.py
@@ -735,7 +735,8 @@ class Swauth(object):
         try:
             conn = self.get_conn()
             conn.request('PUT', path,
-                        headers={'X-Auth-Token': self.get_itoken(req.environ)})
+                        headers={'X-Auth-Token': self.get_itoken(req.environ),
+                                 'Content-Length': '0'})
             resp = conn.getresponse()
             resp.read()
             if resp.status // 100 != 2:


### PR DESCRIPTION
HTTP PUT requires a Content-Length header and many web servers (e.g. nginx)
enforce this limitation. The management utilities swauth-add-{account,user} and
also middleware.Swauth.handle_put_account do not specify Content-Length with
PUT requests, which causes requests routed through nginx to fail.

Fix this by including a Content-Length of zero for all HTTP PUTs.

N.B.: This is not needed for requests performed via make_pre_authed_request().
