### PR TITLE
Add X-Auth-Token-Lifetime and user_set_tokenlifetime option 

### DIFF
--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -41,8 +41,10 @@ use = egg:swauth#swauth
 # useful when a load balancer url should be used by users, but swauth itself is
 # behind the load balancer. Example:
 #   default_swift_cluster = local#https://public.com:8080/v1#http://private.com:8080/v1
-# Number of seconds a newly issued token should be valid for.
+# Number of seconds a newly issued token should be valid for, by default.
 #   token_life = 86400
+# Maximum number of seconds a newly issued token can be valid for.
+#   max_token_life = <same as token_life>
 # Specifies how the user key is stored. The default is 'plaintext', leaving the
 # key unsecured but available for key-signing features if such are ever added.
 # An alternative is 'sha1' which stores only a one-way hash of the key leaving


### PR DESCRIPTION
Hello,

first thank your very much for your work on swauth! 

I just added an configuration option to swauth which allows users to set the token lifetime when requesting a new one. It's off by default and can be enabled with the option user_set_tokenlifetime in the proxy conf. 

Some of our users need tokens with a longer lifetime because they use them in batch jobs. 

Best Regards,

Christian
