### PR TITLE
Swift client import error

### DIFF
--- a/bin/swauth-cleanup-tokens
+++ b/bin/swauth-cleanup-tokens
@@ -25,8 +25,7 @@ from optparse import OptionParser
 from sys import argv, exit
 from time import sleep, time
 
-from swift.common.client import Connection, ClientException
-
+from swiftclient.client import Connection, ClientException
 
 if __name__ == '__main__':
     gettext.install('swauth', unicode=1)


### PR DESCRIPTION
Modify swift client import to work with newer versions (>= 1.7.4). 

Correct this error :
swauth-cleanup-tokens -A https://swift.example.org/auth/ -K swauthkey --purge=account1 
Traceback (most recent call last):
  File "/usr/bin/swauth-cleanup-tokens", line 28, in <module>
    from swift.common.client import Connection, ClientException
ImportError: No module named client
